### PR TITLE
Add fixed/sticky menu

### DIFF
--- a/css/grid.css
+++ b/css/grid.css
@@ -25,6 +25,10 @@
     z-index: 1;
 }
 
+#header-con {
+    position: fixed;
+}
+
 #top-menu {
     position: absolute;
     height: 100vh;
@@ -350,6 +354,11 @@
         grid-template-columns: repeat(12, minmax(0, 1fr));
         grid-column-gap: 18px;
         padding: 15px 40px;
+    }
+
+    #header-con {
+        position: sticky;
+        top: 0;
     }
 
     #burger, #event-title {

--- a/css/main.css
+++ b/css/main.css
@@ -65,8 +65,8 @@ html {
 
 /* Header */
 
+
 #header-con {
-    position: relative;
     z-index: 2;
     box-shadow: 1px 0 5px #eaeaea;
 }


### PR DESCRIPTION
In this commit, the position of the header was changed for different media queries. On mobile, the menu is fixed, and on desktop it is sticky.